### PR TITLE
ci: add cloudflare deploy workflow & smoke test

### DIFF
--- a/com.mrrainbowsmoke.home/.github/workflows/deploy.yml
+++ b/com.mrrainbowsmoke.home/.github/workflows/deploy.yml
@@ -10,14 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Wrangler
-        run: |
-          npm ci --no-audit --prefer-offline || true
-          npm install -g wrangler
+      - name: Authenticate Wrangler (Cloudflare action)
+        uses: cloudflare/wrangler-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Publish to Cloudflare
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          wrangler deploy --api-token "$CLOUDFLARE_API_TOKEN"
+          wrangler deploy
+
+      - name: Smoke test deployed worker
+        if: ${{ success() }}
+        run: |
+          ./scripts/smoke_test.sh
+        shell: bash

--- a/com.mrrainbowsmoke.home/README.md
+++ b/com.mrrainbowsmoke.home/README.md
@@ -56,5 +56,24 @@ You can configure GitHub Actions to deploy on push to `main`. The repository mus
 
 The repo includes a sample workflow at `.github/workflows/deploy.yml` that installs Wrangler and runs `wrangler deploy` using those secrets.
 
+Workflow badge
+--------------
+
+You can add a badge to show the status of the `Deploy Worker` workflow:
+
+```
+[![Deploy Worker](https://github.com/rainbowkillah/cf-worker/actions/workflows/deploy.yml/badge.svg)](https://github.com/rainbowkillah/cf-worker/actions/workflows/deploy.yml)
+```
+
+Setting up secrets
+------------------
+
+1. Go to your repository Settings → Secrets & variables → Actions.
+2. Add `CLOUDFLARE_API_TOKEN` with a token scoped to:
+	- Account: Read & Write for Workers, KV, D1 and R2 as needed (restrict as appropriate).
+	- Workers Scripts: write
+3. Add `CLOUDFLARE_ACCOUNT_ID` with your account id.
+
+
 
 


### PR DESCRIPTION
Adds official cloudflare/wrangler-action, runs smoke test, and documents required secrets + badge in README.